### PR TITLE
Change circular_check_box to resemble the material version

### DIFF
--- a/lib/circular_check_box.dart
+++ b/lib/circular_check_box.dart
@@ -3,14 +3,25 @@
 // found in the LICENSE file.
 
 // Modified by Mash Ibtesum
+// Modified by Lorenzo Calisti
 
 library circular_check_box;
 
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter/material.dart';
 
-// Really Janky implementation of circular checkbox
+/// A material design circular checkbox.
+///
+/// This checkbox is a modified version of `flutter/material.dart` [Checkbox],
+/// his behaviour is the same except this draws a circular shape instead of
+/// a squared.
+///
+/// Requires one of its ancestors to be a [Material] widget.
+///
+/// See also:
+///
+///  * [Checkbox]
 class CircularCheckBox extends StatefulWidget {
   /// Creates a material design circular checkbox.
   ///
@@ -27,35 +38,42 @@ class CircularCheckBox extends StatefulWidget {
   /// * [onChanged], which is called when the value of the checkbox should
   ///   change. It can be set to null to disable the checkbox.
   ///
-  /// The value of [tristate] must not be null.
+  /// The values of [tristate] and [autofocus] must not be null.
   const CircularCheckBox({
     Key key,
     @required this.value,
     this.tristate = false,
     @required this.onChanged,
     this.activeColor,
+    this.checkColor,
     this.inactiveColor,
     this.disabledColor,
+    this.focusColor,
+    this.hoverColor,
     this.materialTapTargetSize,
-  })  : assert(tristate != null),
-        assert(tristate || value != null),
-        super(key: key);
+    this.visualDensity,
+    this.focusNode,
+    this.autofocus = false,
+  }) : assert(tristate != null),
+      assert(tristate || value != null),
+      assert(autofocus != null),
+      super(key: key);
 
-  /// Whether this CircularCheckBox is checked.
+  /// Whether this checkbox is checked.
   ///
   /// This property must not be null.
   final bool value;
 
-  /// Called when the value of the CircularCheckBox should change.
+  /// Called when the value of the checkbox should change.
   ///
-  /// The CircularCheckBox passes the new value to the callback but does not actually
-  /// change state until the parent widget rebuilds the CircularCheckBox with the new
+  /// The checkbox passes the new value to the callback but does not actually
+  /// change state until the parent widget rebuilds the checkbox with the new
   /// value.
   ///
-  /// If this callback is null, the CircularCheckBox will be displayed as disabled
+  /// If this callback is null, the checkbox will be displayed as disabled
   /// and will not respond to input gestures.
   ///
-  /// When the CircularCheckBox is tapped, if [tristate] is false (the default) then
+  /// When the checkbox is tapped, if [tristate] is false (the default) then
   /// the [onChanged] callback will be applied to `!value`. If [tristate] is
   /// true this callback cycle from false to true to null.
   ///
@@ -75,21 +93,40 @@ class CircularCheckBox extends StatefulWidget {
   /// ```
   final ValueChanged<bool> onChanged;
 
-  /// The color to use when this CircularCheckBox is checked.
+  /// The color to use when this checkbox is checked.
   ///
   /// Defaults to [ThemeData.toggleableActiveColor].
   final Color activeColor;
+
+  /// The color to use for the check icon when this checkbox is checked.
+  ///
+  /// Defaults to Color(0xFFFFFFFF)
+  final Color checkColor;
+
+  /// The color to use when this checkbox is inactive.
+  ///
+  /// Defaults to [ThemeData.unselectedWidgetColor].
   final Color inactiveColor;
+
+  /// The color to use when this checkbox is disables.
+  ///
+  /// Defaults to [ThemeData.disabledColor].
   final Color disabledColor;
 
-  /// If true the CircularCheckBox's [value] can be true, false, or null.
+  /// The color for the checkbox's [Material] when it has the input focus.
+  final Color focusColor;
+
+  /// The color for the checkbox's [Material] when a pointer is hovering over it.
+  final Color hoverColor;
+
+  /// If true the checkbox's [value] can be true, false, or null.
   ///
-  /// CircularCheckBox displays a dash when its value is null.
+  /// Checkbox displays a dash when its value is null.
   ///
-  /// When a tri-state CircularCheckBox is tapped its [onChanged] callback will be
-  /// applied to true if the current value is null or false, false otherwise.
-  /// Typically tri-state CircularCheckBoxes are disabled (the onChanged callback is
-  /// null) so they don't respond to taps.
+  /// When a tri-state checkbox ([tristate] is true) is tapped, its [onChanged]
+  /// callback will be applied to true if the current value is false, to null if
+  /// value is true, and to false if value is null (i.e. it cycles through false
+  /// => true => null => false when tapped).
   ///
   /// If tristate is false (the default), [value] must not be null.
   final bool tristate;
@@ -100,18 +137,83 @@ class CircularCheckBox extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///   * [MaterialTapTargetSize], for a description of how this affects tap targets.
+  ///  * [MaterialTapTargetSize], for a description of how this affects tap targets.
   final MaterialTapTargetSize materialTapTargetSize;
 
-  /// The width of a CircularCheckBox widget.
+  /// Defines how compact the checkbox's layout will be.
+  ///
+  /// {@macro flutter.material.themedata.visualDensity}
+  ///
+  /// See also:
+  ///
+  ///  * [ThemeData.visualDensity], which specifies the [density] for all widgets
+  ///    within a [Theme].
+  final VisualDensity visualDensity;
+
+  /// {@macro flutter.widgets.Focus.focusNode}
+  final FocusNode focusNode;
+
+  /// {@macro flutter.widgets.Focus.autofocus}
+  final bool autofocus;
+
+  /// The width of a checkbox widget.
   static const double width = 18.0;
 
   @override
   _CircularCheckBoxState createState() => _CircularCheckBoxState();
 }
 
-class _CircularCheckBoxState extends State<CircularCheckBox>
-    with TickerProviderStateMixin {
+class _CircularCheckBoxState extends State<CircularCheckBox> with TickerProviderStateMixin {
+  bool get enabled => widget.onChanged != null;
+  Map<LocalKey, ActionFactory> _actionMap;
+
+  @override
+  void initState() {
+    super.initState();
+    _actionMap = <LocalKey, ActionFactory>{
+      ActivateAction.key: _createAction,
+    };
+  }
+
+  void _actionHandler(FocusNode node, Intent intent){
+    if (widget.onChanged != null) {
+      switch (widget.value) {
+        case false:
+          widget.onChanged(true);
+          break;
+        case true:
+          widget.onChanged(widget.tristate ? null : false);
+          break;
+        default: // case null:
+          widget.onChanged(false);
+          break;
+      }
+    }
+    final RenderObject renderObject = node.context.findRenderObject();
+    renderObject.sendSemanticsEvent(const TapSemanticEvent());
+  }
+
+  Action _createAction() {
+    return CallbackAction(
+      ActivateAction.key,
+      onInvoke: _actionHandler,
+    );
+  }
+
+  bool _focused = false;
+  void _handleFocusHighlightChanged(bool focused) {
+    if (focused != _focused) {
+      setState(() { _focused = focused; });
+    }
+  }
+
+  bool _hovering = false;
+  void _handleHoverChanged(bool hovering) {
+    if (hovering != _hovering) {
+      setState(() { _hovering = hovering; });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
@@ -119,24 +221,41 @@ class _CircularCheckBoxState extends State<CircularCheckBox>
     Size size;
     switch (widget.materialTapTargetSize ?? themeData.materialTapTargetSize) {
       case MaterialTapTargetSize.padded:
-        size = const Size(
-            2 * kRadialReactionRadius + 8.0, 2 * kRadialReactionRadius + 8.0);
+        size = const Size(2 * kRadialReactionRadius + 8.0, 2 * kRadialReactionRadius + 8.0);
         break;
       case MaterialTapTargetSize.shrinkWrap:
         size = const Size(2 * kRadialReactionRadius, 2 * kRadialReactionRadius);
         break;
     }
+    size += (widget.visualDensity ?? themeData.visualDensity).baseSizeAdjustment;
     final BoxConstraints additionalConstraints = BoxConstraints.tight(size);
-    return _CircularCheckBoxRenderObjectWidget(
-      value: widget.value,
-      tristate: widget.tristate,
-      activeColor: widget.activeColor ?? themeData.toggleableActiveColor,
-      inactiveColor: widget.onChanged != null
-          ? widget.inactiveColor ?? themeData.unselectedWidgetColor
-          : widget.disabledColor ?? themeData.disabledColor,
-      onChanged: widget.onChanged,
-      additionalConstraints: additionalConstraints,
-      vsync: this,
+    return FocusableActionDetector(
+      actions: _actionMap,
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      enabled: enabled,
+      onShowFocusHighlight: _handleFocusHighlightChanged,
+      onShowHoverHighlight: _handleHoverChanged,
+      child: Builder(
+        builder: (BuildContext context) {
+          return _CircularCheckBoxRenderObjectWidget(
+            value: widget.value,
+            tristate: widget.tristate,
+            activeColor: widget.activeColor ?? themeData.toggleableActiveColor,
+            checkColor: widget.checkColor ?? const Color(0xFFFFFFFF),
+            inactiveColor: enabled ?
+            widget.inactiveColor ?? themeData.unselectedWidgetColor:
+            widget.disabledColor ?? themeData.disabledColor,
+            focusColor: widget.focusColor ?? themeData.focusColor,
+            hoverColor: widget.hoverColor ?? themeData.hoverColor,
+            onChanged: widget.onChanged,
+            additionalConstraints: additionalConstraints,
+            vsync: this,
+            hasFocus: _focused,
+            hovering: _hovering,
+          );
+        },
+      ),
     );
   }
 }
@@ -147,78 +266,108 @@ class _CircularCheckBoxRenderObjectWidget extends LeafRenderObjectWidget {
     @required this.value,
     @required this.tristate,
     @required this.activeColor,
+    @required this.checkColor,
     @required this.inactiveColor,
+    @required this.focusColor,
+    @required this.hoverColor,
     @required this.onChanged,
     @required this.vsync,
     @required this.additionalConstraints,
-  })  : assert(tristate != null),
-        assert(tristate || value != null),
-        assert(activeColor != null),
-        assert(inactiveColor != null),
-        assert(vsync != null),
-        super(key: key);
+    @required this.hasFocus,
+    @required this.hovering,
+  }) : assert(tristate != null),
+      assert(tristate || value != null),
+      assert(activeColor != null),
+      assert(inactiveColor != null),
+      assert(vsync != null),
+      super(key: key);
 
   final bool value;
   final bool tristate;
+  final bool hasFocus;
+  final bool hovering;
   final Color activeColor;
+  final Color checkColor;
   final Color inactiveColor;
+  final Color focusColor;
+  final Color hoverColor;
   final ValueChanged<bool> onChanged;
   final TickerProvider vsync;
   final BoxConstraints additionalConstraints;
 
   @override
-  _RenderCircularCheckBox createRenderObject(BuildContext context) =>
-      _RenderCircularCheckBox(
-        value: value,
-        tristate: tristate,
-        activeColor: activeColor,
-        inactiveColor: inactiveColor,
-        onChanged: onChanged,
-        vsync: vsync,
-        additionalConstraints: additionalConstraints,
-      );
+  _RenderCircularCheckBox createRenderObject(BuildContext context) => _RenderCircularCheckBox(
+    value: value,
+    tristate: tristate,
+    activeColor: activeColor,
+    checkColor: checkColor,
+    inactiveColor: inactiveColor,
+    focusColor: focusColor,
+    hoverColor: hoverColor,
+    onChanged: onChanged,
+    vsync: vsync,
+    additionalConstraints: additionalConstraints,
+    hasFocus: hasFocus,
+    hovering: hovering,
+  );
 
   @override
-  void updateRenderObject(
-      BuildContext context, _RenderCircularCheckBox renderObject) {
+  void updateRenderObject(BuildContext context, _RenderCircularCheckBox renderObject) {
     renderObject
       ..value = value
       ..tristate = tristate
       ..activeColor = activeColor
+      ..checkColor = checkColor
       ..inactiveColor = inactiveColor
+      ..focusColor = focusColor
+      ..hoverColor = hoverColor
       ..onChanged = onChanged
       ..additionalConstraints = additionalConstraints
-      ..vsync = vsync;
+      ..vsync = vsync
+      ..hasFocus = hasFocus
+      ..hovering = hovering;
   }
 }
 
 const double _kEdgeSize = CircularCheckBox.width;
+const double _kStrokeWidth = 2.0;
 
 class _RenderCircularCheckBox extends RenderToggleable {
   _RenderCircularCheckBox({
     bool value,
     bool tristate,
     Color activeColor,
+    this.checkColor,
     Color inactiveColor,
+    Color focusColor,
+    Color hoverColor,
     BoxConstraints additionalConstraints,
     ValueChanged<bool> onChanged,
+    bool hasFocus,
+    bool hovering,
     @required TickerProvider vsync,
-  })  : _oldValue = value,
-        super(
-          value: value,
-          tristate: tristate,
-          activeColor: activeColor,
-          inactiveColor: inactiveColor,
-          onChanged: onChanged,
-          additionalConstraints: additionalConstraints,
-          vsync: vsync,
-        );
+  }) : _oldValue = value,
+      super(
+      value: value,
+      tristate: tristate,
+      activeColor: activeColor,
+      inactiveColor: inactiveColor,
+      focusColor: focusColor,
+      hoverColor: hoverColor,
+      onChanged: onChanged,
+      additionalConstraints: additionalConstraints,
+      vsync: vsync,
+      hasFocus: hasFocus,
+      hovering: hovering,
+    );
 
   bool _oldValue;
+  Color checkColor;
 
   @override
   set value(bool newValue) {
-    if (newValue == value) return;
+    if (newValue == value)
+      return;
     _oldValue = value;
     super.value = newValue;
   }
@@ -229,23 +378,31 @@ class _RenderCircularCheckBox extends RenderToggleable {
     config.isChecked = value == true;
   }
 
-  // The CircularCheckBox's border color if value == false, or its fill color when
+  // The checkbox's border color if value == false, or its fill color when
   // value == true or null.
   Color _colorAt(double t) {
     // As t goes from 0.0 to 0.25, animate from the inactiveColor to activeColor.
     return onChanged == null
-        ? inactiveColor
-        : (t >= 0.25
-            ? activeColor
-            : Color.lerp(inactiveColor, activeColor, t * 4.0));
+      ? inactiveColor
+      : (t >= 0.25
+      ? activeColor
+      : Color.lerp(inactiveColor, activeColor, t * 4.0));
   }
 
-  // White stroke used to paint the check and dash.
-  void _initStrokePaint(Paint paint) {
-    paint
-      ..color = const Color(0xFFFFFFFF)
+  // checkColor stroke used to paint the check and dash.
+  Paint _createStrokePaint() {
+    return Paint()
+      ..color = checkColor
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 2.0;
+      ..strokeWidth = _kStrokeWidth;
+  }
+
+  void _drawCircleBorder(Canvas canvas, Offset center, double radius, double t, Paint paint) {
+    assert(t >= 0.0 && t <= 0.5);
+    paint
+      ..strokeWidth = _kStrokeWidth
+      ..style = PaintingStyle.stroke;
+    canvas.drawCircle(center, radius, paint);
   }
 
   void _drawCheck(Canvas canvas, Offset origin, double t, Paint paint) {
@@ -288,55 +445,47 @@ class _RenderCircularCheckBox extends RenderToggleable {
     final Canvas canvas = context.canvas;
     paintRadialReaction(canvas, offset, size.center(Offset.zero));
 
-    final Offset origin =
-        offset + (size / 2.0 - const Size.square(_kEdgeSize) / 2.0);
+    final Paint strokePaint = _createStrokePaint();
+    final Offset origin = offset + (size / 2.0 - const Size.square(_kEdgeSize) / 2.0 as Offset);
     final AnimationStatus status = position.status;
-    final double tNormalized =
-        status == AnimationStatus.forward || status == AnimationStatus.completed
-            ? position.value
-            : 1.0 - position.value;
+    final double tNormalized = status == AnimationStatus.forward || status == AnimationStatus.completed
+      ? position.value
+      : 1.0 - position.value;
     final Offset center = (offset & size).center;
 
     // Four cases: false to null, false to true, null to false, true to false
     if (_oldValue == false || value == false) {
       final double t = value == false ? 1.0 - tNormalized : tNormalized;
-
       final Paint paint = Paint()..color = _colorAt(t);
 
-      final Paint paintX = Paint()
-        ..color = Color.lerp(inactiveColor, Colors.red, position.value)
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 1.0;
       if (t <= 0.5) {
-        canvas.drawCircle(center, 11, paintX);
+        _drawCircleBorder(canvas, center, 11, t, paint);
       } else {
         canvas.drawCircle(center, 13, paint);
 
-        _initStrokePaint(paint);
         final double tShrink = (t - 0.5) * 2.0;
-        if (_oldValue == null)
-          _drawDash(canvas, origin, tShrink, paint);
+        if (_oldValue == null || value == null)
+          _drawDash(canvas, origin, tShrink, strokePaint);
         else
-          _drawCheck(canvas, origin, tShrink, paint);
+          _drawCheck(canvas, origin, tShrink, strokePaint);
       }
     } else {
       // Two cases: null to true, true to null
-      final Paint paint = Paint()..color = _colorAt(1.0);
-      canvas.drawCircle(center, 13, paint);
+      final Paint paint = Paint() ..color = _colorAt(1.0);
+      canvas.drawCircle(center, 12, paint);
 
-      _initStrokePaint(paint);
       if (tNormalized <= 0.5) {
         final double tShrink = 1.0 - tNormalized * 2.0;
         if (_oldValue == true)
-          _drawCheck(canvas, origin, tShrink, paint);
+          _drawCheck(canvas, origin, tShrink, strokePaint);
         else
-          _drawDash(canvas, origin, tShrink, paint);
+          _drawDash(canvas, origin, tShrink, strokePaint);
       } else {
         final double tExpand = (tNormalized - 0.5) * 2.0;
         if (value == true)
-          _drawCheck(canvas, origin, tExpand, paint);
+          _drawCheck(canvas, origin, tExpand, strokePaint);
         else
-          _drawDash(canvas, origin, tExpand, paint);
+          _drawDash(canvas, origin, tExpand, strokePaint);
       }
     }
   }


### PR DESCRIPTION
Add the ability to customize check, focus and hover color
Add the use of FocusNode and autofocus using FocusableActionDetector
Add the use of VisualDensity
Change the way the circular border is drawn, using Paint's strokeWidth and style